### PR TITLE
Adding @import feature

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -89,7 +89,7 @@ document.webL10n = (function(window, document, undefined) {
       }
     }
     
-    //Load a resource checking that we don't have any cycle
+    // Load a resource checking that we don't have any cycle
     function loadImport(resource) {
       if (gParsedFiles.indexOf(resource) > -1) {
         console.log('Cycle detected with resource: ' + resource);
@@ -137,7 +137,7 @@ document.webL10n = (function(window, document, undefined) {
     xhr.onreadystatechange = function() {
       if (xhr.readyState == 4) {
         if (xhr.status == 200) {
-          gParsedFiles.push(res); //Save the parsed files to detect cycles
+          gParsedFiles.push(res); // Save the parsed files to detect cycles
           if (onSuccess) {
             onSuccess(xhr.responseText);
           }
@@ -191,7 +191,7 @@ document.webL10n = (function(window, document, undefined) {
     function l10nResourceLink(link) {
       var href = link.href;
       var type = link.type;
-      gParsedFiles.push(href); //This should go in the success callback, but the imports will load synchronously
+      gParsedFiles.push(href); // save it, @includes will be load synchronously
       this.load = function(lang, callback) {
         var applied = lang;
         loadAndParse(href, lang, callback, function() {


### PR DESCRIPTION
Just refactor some code to do the load and the parsing reusable in other files using the @import rule.

Tries to detect cycles, but won't differentiate between:

@import url(locales/data.fr.properties)
@import url(http://mydomain.com/locales/data.fr.properties)

cause actually they could be two different files.

In the import files won't detect any language sections, elements expected are comments, proper definitions, and also more imports. So, yes, nested imports are allowed.

Cheers!
