### PR TITLE
Fix support for SVG in WebKit browsers

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -836,7 +836,7 @@ document.webL10n = (function(window, document, undefined) {
     // for the node content, replace the content of the first child textNode
     // and clear other child textNodes
     if (data[gTextProp]) { // XXX
-      if (element.children.length === 0) {
+      if (getChildElementCount(element) === 0) {
         element[gTextProp] = data[gTextProp];
       } else {
         var children = element.childNodes,
@@ -863,6 +863,20 @@ document.webL10n = (function(window, document, undefined) {
     for (var k in data) {
       element[k] = data[k];
     }
+  }
+
+  function getChildElementCount(element) {
+    // WebKit browsers don't currently support 'children' on SVG elements.
+    if (element.children)
+      return element.children.length;
+    if (typeof element.childElementCount !== "undefined")
+      return element.childElementCount;
+
+    var count = 0;
+    for (var i = 0; i < element.childNodes.length; i++) {
+      count += element.nodeType === 1 ? 1 : 0;
+    }
+    return count;
   }
 
   // translate an HTML subtree


### PR DESCRIPTION
WebKit browsers don't currently appear to support Element.children.
Hence errors are produced in translateElement when SVG elements
(including inline SVG) are encountered.
