### PR TITLE
Replace rel="resource" by rel="prefetch"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here’s a quick way to get a multilingual HTML page:
 <html>
 <head>
   <script type="text/javascript" src="l10n.js"></script>
-  <link rel="resource" type="application/l10n" href="data.ini" />
+  <link rel="prefetch" type="application/l10n" href="data.ini" />
 </head>
 <body>
   <button data-l10n-id="test" title="click me!">This is a test</button>
@@ -168,8 +168,8 @@ Further thoughts
 For mobile apps, here’s what I’d like to do:
 
 ```html
-<link rel="resource" type="application/l10n" href="data.ini" />
-<link rel="resource" type="application/l10n" href="mobile.ini"
+<link rel="prefetch" type="application/l10n" href="data.ini" />
+<link rel="prefetch" type="application/l10n" href="mobile.ini"
       media="screen and (max-width: 640px)" />
 ```
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title> webL10n test page </title>
   <meta charset="utf-8" />
 
-  <link rel="resource" type="application/l10n" href="l10n/locales.ini" />
+  <link rel="prefetch" type="application/l10n" href="l10n/locales.ini" />
   <script type="text/javascript" src="l10n.js"></script>
   <script type="text/javascript">
     function onLocalized() {


### PR DESCRIPTION
Resource is not a valid keyword here, and prefetch seems to fit.

http://www.w3.org/html/wg/drafts/html/master/links.html#link-type-prefetch

<blockquote>4.12.5.9 Link type "prefetch"<br />
The prefetch keyword may be used with link, a, and area elements. This keyword creates an external resource link.<br />
The prefetch keyword indicates that preemptively fetching and caching the specified resource is likely to be beneficial, as it is highly likely that the user will require this resource.<br />
There is no default type for resources given by the prefetch keyword.</blockquote>
