### PR TITLE
Uppercase country/region code, fixes #35

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -288,7 +288,9 @@ document.webL10n = (function(window, document, undefined) {
     callback = callback || function _callback() {};
 
     clear();
-    gLanguage = lang;
+    gLanguage = lang = lang.replace(/-[a-z]{2}$/i, function(str) {
+      return str.toUpperCase();
+    });
 
     // check all <link type="application/l10n" href="..." /> nodes
     // and load the resource files

--- a/l10n.js
+++ b/l10n.js
@@ -998,12 +998,8 @@ document.webL10n = (function(window, document, undefined) {
 
     // dummy `console.log' and `console.warn' functions
     if (!window.console) {
-      consoleLog = function(message) {}; // just ignore console.log calls
-      consoleWarn = function(message) {
-        if (gDEBUG) {
-          alert('[l10n] ' + message); // vintage debugging, baby!
-        }
-      };
+      // just ignore debug calls
+      consoleLog = consoleWarn = function(message) {};
     }
 
     // XMLHttpRequest for IE6


### PR DESCRIPTION
The uppercase issue is only workaround-able from `l10n.js`; I also add a minor fix that will stop `alert()` in browsers without `console.log()`.
