### PR TITLE
Add support for attributes in webL10n.get, and corrected behavior of the fallback argument

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -805,10 +805,14 @@ document.webL10n = (function(window, document, undefined) {
    */
 
   // fetch an l10n object, warn if not found, apply `args' if possible
-  function getL10nData(key, args) {
+  function getL10nData(key, args, fallback) {
     var data = gL10nData[key];
     if (!data) {
       consoleWarn('#' + key + ' is undefined.');
+      if (!fallback) {
+        return null;
+      }
+      data = fallback;
     }
 
     /** This is where l10n expressions should be processed.
@@ -1103,19 +1107,21 @@ document.webL10n = (function(window, document, undefined) {
   // cross-browser API (sorry, oldIE doesn't support getters & setters)
   return {
     // get a localized string
-    get: function(key, args, fallback) {
+    get: function(key, args, fallbackString) {
       var index = key.lastIndexOf('.');
       var prop = gTextProp;
       if (index > 0) { // An attribute has been specified
         prop = key.substr(index + 1);
         key = key.substring(0, index);
       }
-      var data = getL10nData(key, args);
-      if (data && prop in data) { // XXX double-check this
-        return data[prop];
+      var fallback;
+      if (fallbackString) {
+        fallback = {};
+        fallback[prop] = fallbackString;
       }
-      if (typeof fallback === 'string') {
-        return fallback;
+      var data = getL10nData(key, args, fallback);
+      if (data && prop in data) {
+        return data[prop];
       }
       return '{{' + key + '}}';
     },

--- a/l10n.js
+++ b/l10n.js
@@ -1104,9 +1104,15 @@ document.webL10n = (function(window, document, undefined) {
   return {
     // get a localized string
     get: function(key, args, fallback) {
+      var index = key.lastIndexOf('.');
+      var prop = gTextProp;
+      if (index > 0) { // An attribute has been specified
+        prop = key.substr(index + 1);
+        key = key.substring(0, index);
+      }
       var data = getL10nData(key, args) || fallback;
       if (data) { // XXX double-check this
-        return gTextProp in data ? data[gTextProp] : '';
+        return prop in data ? data[prop] : '';
       }
       return '{{' + key + '}}';
     },

--- a/l10n.js
+++ b/l10n.js
@@ -1110,9 +1110,12 @@ document.webL10n = (function(window, document, undefined) {
         prop = key.substr(index + 1);
         key = key.substring(0, index);
       }
-      var data = getL10nData(key, args) || fallback;
-      if (data) { // XXX double-check this
-        return prop in data ? data[prop] : '';
+      var data = getL10nData(key, args);
+      if (data && prop in data) { // XXX double-check this
+        return data[prop];
+      }
+      if (typeof fallback === 'string') {
+        return fallback;
       }
       return '{{' + key + '}}';
     },

--- a/l10n.js
+++ b/l10n.js
@@ -61,13 +61,13 @@ document.webL10n = (function(window, document, undefined) {
     if (gDEBUG >= 2) {
       console.log('[l10n] ' + message);
     }
-  };
+  }
 
   function consoleWarn(message) {
     if (gDEBUG) {
       console.warn('[l10n] ' + message);
     }
-  };
+  }
 
 
   /**
@@ -281,7 +281,7 @@ document.webL10n = (function(window, document, undefined) {
         successCallback();
       }
     }, failureCallback, gAsyncResourceLoading);
-  };
+  }
 
   // load and parse all resources for the specified locale
   function loadLocale(lang, callback) {
@@ -294,7 +294,7 @@ document.webL10n = (function(window, document, undefined) {
     // and load the resource files
     var langLinks = getL10nResourceLinks();
     var langCount = langLinks.length;
-    if (langCount == 0) {
+    if (langCount === 0) {
       // we might have a pre-compiled dictionary instead
       var dict = getL10nDictionary();
       if (dict && dict.locales && dict.default_locale) {
@@ -323,7 +323,7 @@ document.webL10n = (function(window, document, undefined) {
     };
 
     // load all resource files
-    function l10nResourceLink(link) {
+    function L10nResourceLink(link) {
       var href = link.href;
       var type = link.type;
       this.load = function(lang, callback) {
@@ -337,7 +337,7 @@ document.webL10n = (function(window, document, undefined) {
     }
 
     for (var i = 0; i < langCount; i++) {
-      var resource = new l10nResourceLink(langLinks[i]);
+      var resource = new L10nResourceLink(langLinks[i]);
       var rv = resource.load(lang, onResourceLoaded);
       if (rv != lang) { // lang not found, used default resource instead
         consoleWarn('"' + lang + '" resource not found');
@@ -1025,7 +1025,7 @@ document.webL10n = (function(window, document, undefined) {
           }
         };
         xhr.send(null);
-      }
+      };
     }
 
     // worst hack ever for IE6 and IE7


### PR DESCRIPTION
Before this PR, it was impossible to programatically get the value of an localized attribute. I checked the [implementation of how attributes in the properties file are parsed](https://github.com/fabi1cazenave/webL10n/blob/b18c753c6fe81e733d86660d421ace7a7880e90f/l10n.js#L264-L268), and derived a method that recognized attributes, if specified.

Read commit message of dd0703a662a623e550317e3437f6850796606e9c for an explanation of the second change set. In a nutshell:

- Initial implementation: `webL10n.get('non_existent', null, 'fallback') === 'fallback'`
- Later implementation: `webL10n.get('non_existent', null, 'fallback') === '';` (expected 'fallback')
- My commit = back to initial implementation