### PR TITLE
chore(bower): add .bower.json (already registred)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "webL10n",
+  "version": "0.0.1",
+  "homepage": "https://github.com/fabi1cazenave/webL10n",
+  "authors": [
+    "Fabien Cazenave <kaze@kompozer.net>",
+    "Édouard Lopez [bower] <dev+git@edouard-lopez.com>"
+  ],
+  "description": "Client-side internationalization / localization library",
+  "main": "./l10n.js",
+  "keywords": [
+    "l10n",
+    "i18n",
+    "localization",
+    "internationalization",
+    "client-side",
+    "mozilla"
+  ],
+  "license": "WTFPL",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I created a .bower.json and registred it using

```
bower register webL10n git@github.com:edouard-lopez/webL10n.git
```

So now you can simply install it using:

```
bower install webL10n
```

More info on registering package at https://github.com/bower/bower#registering-packages

**N.B.:** I will update the endpoint to your repo when the request is merge into your repo.
