### PR TITLE
Case-insensitive language comparisons per RFC 4646

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -159,7 +159,7 @@ document.webL10n = (function(window, document, undefined) {
    *    URL of the l10n resource to parse.
    *
    * @param {string} lang
-   *    locale (language) to parse.
+   *    locale (language) to parse. Must be a lowercase string.
    *
    * @param {Function} successCallback
    *    triggered when the l10n resource has been successully parsed.
@@ -220,7 +220,10 @@ document.webL10n = (function(window, document, undefined) {
           if (extendedSyntax) {
             if (reSection.test(line)) { // section start?
               match = reSection.exec(line);
-              currentLang = match[1];
+              // RFC 4646, section 4.4, "All comparisons MUST be performed
+              // in a case-insensitive manner."
+
+              currentLang = match[1].toLowerCase();
               skipLang = (currentLang !== '*') &&
                   (currentLang !== lang) && (currentLang !== genericLang);
               continue;
@@ -285,6 +288,12 @@ document.webL10n = (function(window, document, undefined) {
 
   // load and parse all resources for the specified locale
   function loadLocale(lang, callback) {
+    // RFC 4646, section 2.1 states that language tags have to be treated as
+    // case-insensitive. Convert to lowercase for case-insensitive comparisons.
+    if (lang) {
+      lang = lang.toLowerCase();
+    }
+
     callback = callback || function _callback() {};
 
     clear();
@@ -299,7 +308,19 @@ document.webL10n = (function(window, document, undefined) {
       var dict = getL10nDictionary();
       if (dict && dict.locales && dict.default_locale) {
         consoleLog('using the embedded JSON directory, early way out');
-        gL10nData = dict.locales[lang] || dict.locales[dict.default_locale];
+        gL10nData = dict.locales[lang];
+        if (!gL10nData) {
+          var defaultLocale = dict.default_locale.toLowerCase();
+          for (var anyCaseLang in dict.locales) {
+            anyCaseLang = anyCaseLang.toLowerCase();
+            if (anyCaseLang === lang) {
+              gL10nData = dict.locales[lang];
+              break;
+            } else if (anyCaseLang === defaultLocale) {
+              gL10nData = dict.locales[defaultLocale];
+            }
+          }
+        }
         callback();
       } else {
         consoleLog('no resource to load, early way out');

--- a/l10n.js
+++ b/l10n.js
@@ -205,7 +205,7 @@ document.webL10n = (function(window, document, undefined) {
       function parseRawLines(rawText, extendedSyntax) {
         var entries = rawText.replace(reBlank, '').split(/[\r\n]+/);
         var currentLang = '*';
-        var genericLang = lang.replace(/-[a-z]+$/i, '');
+        var genericLang = lang.split('-', 1)[0];
         var skipLang = false;
         var match = '';
 


### PR DESCRIPTION
Fixes #35, supersedes #36
Fixes #46, supersedes #47

http://tools.ietf.org/html/rfc4646#page-6

> The tags and their subtags, including private use and extensions, are
   to be treated as case insensitive: there exist conventions for the
   capitalization of some of the subtags, but these MUST NOT be taken to
   carry meaning.

http://tools.ietf.org/html/rfc4646#section-4.4

>   Canonicalization of language tags does not imply anything about the
   use of upper or lowercase letters when processing or comparing
   subtags (and as described in Section 2.1).  All comparisons MUST be
   performed in a case-insensitive manner.