### PR TITLE
Wait until gReadyState == 'complete' before triggering firing onready

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -339,9 +339,9 @@ document.webL10n = (function(window, document, undefined) {
       } else {
         consoleLog('no resource to load, early way out');
       }
+      gReadyState = 'complete';
       // early way out
       fireL10nReadyEvent(lang);
-      gReadyState = 'complete';
       return;
     }
 
@@ -352,8 +352,8 @@ document.webL10n = (function(window, document, undefined) {
       gResourceCount++;
       if (gResourceCount >= langCount) {
         callback();
-        fireL10nReadyEvent(lang);
         gReadyState = 'complete';
+        fireL10nReadyEvent(lang);
       }
     };
 
@@ -1180,7 +1180,7 @@ document.webL10n = (function(window, document, undefined) {
     ready: function(callback) {
       if (!callback) {
         return;
-      } else if (gReadyState == 'complete' || gReadyState == 'interactive') {
+      } else if (gReadyState == 'complete') {
         window.setTimeout(function() {
           callback();
         });


### PR DESCRIPTION
gReadyState == 'interactive' is before all external localization files are loaded. The localization event itself is also triggered right when gReadyState == 'complete'. So we have to wait until gReadyState == 'complete' before calling the callback.

Fixes https://github.com/fabi1cazenave/webL10n/issues/64#issuecomment-121959939 (@paulguz)