### PR TITLE
Added option to reload webL10n

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ welcome = welcome, {{user}}!
 welcome = bienvenue, {{user}} !
 ```
 
+**Handling dynamic translations**
+
+You can also re-load webL10n, so it will translate all the elements on the page again (including the newly created elements). This is useful, for example, after an AJAX load call, after creating new DOM elements through Javascript code or when using some mobile app framework that copies the content to a new div, instead of directly displaying it. Just call:
+
+```javascript
+document.webL10n.reload();
+```
+
+Real-world example:
+
+```javascript
+$("#page-content").load("pagecontent.html", function() {
+	document.webL10n.reload(); // it will translate the strings on the loaded content
+});
+```
+
 
 Advanced usage
 --------------

--- a/l10n.js
+++ b/l10n.js
@@ -23,7 +23,7 @@
 /*jshint browser: true, devel: true, es5: true, globalstrict: true */
 'use strict';
 
-document.webL10n = (function(window, document, undefined) {
+document.webL10nProt = function(window, document, undefined) {
   var gL10nData = {};
   var gTextData = '';
   var gTextProp = 'textContent';
@@ -1149,6 +1149,11 @@ document.webL10n = (function(window, document, undefined) {
       return '{{' + key + '}}';
     },
 
+    // re-translates a page (useful after AJAX loads)
+    reload: function() {
+      return document.webL10n = document.webL10nProt(window, document);
+    },
+
     // debug
     getData: function() { return gL10nData; },
     getText: function() { return gTextData; },
@@ -1199,7 +1204,9 @@ document.webL10n = (function(window, document, undefined) {
       }
     }
   };
-}) (window, document);
+};
+
+document.webL10n = document.webL10nProt(window, document);
 
 // gettext-like shortcut for document.webL10n.get
 if (window._ === undefined) {


### PR DESCRIPTION
This option will re-translate all the strings, including the ones from the newly created elements (like after AJAX-load call).

Example:

``` javascript
$("#page-content").load("pagecontent.html", function() {
    document.webL10n.reload(); // it will translate the strings on the loaded content
});
```
