### PR TITLE
Add minimal support for WebExtensions

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -1000,7 +1000,8 @@ document.webL10n = (function(window, document, undefined) {
 
     // most browsers expose the UI language as `navigator.language'
     // but IE uses `navigator.userLanguage' instead
-    var userLocale = navigator.language || navigator.userLanguage;
+    var userLocale = chrome.i18n.getUILanguage() || navigator.language ||
+        navigator.userLanguage;
     consoleLog('loading [' + userLocale + '] resources, ' +
         (gAsyncResourceLoading ? 'asynchronously.' : 'synchronously.'));
 


### PR DESCRIPTION
Add minimal support for WebExtensions.

From Firefox v59 on, you can test localizing your addon by installing
language pack for the language and then setting intl.locale.requested
about:config preference for that language.